### PR TITLE
Adaptive stack allocations

### DIFF
--- a/tests/hamming_test.go
+++ b/tests/hamming_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/neuneck/smetrics"
 )
 
 func TestHamming(t *testing.T) {

--- a/tests/jaro-winkler_test.go
+++ b/tests/jaro-winkler_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/neuneck/smetrics"
 )
 
 func TestJaroWinkler(t *testing.T) {

--- a/tests/jaro_test.go
+++ b/tests/jaro_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/neuneck/smetrics"
 )
 
 func TestJaro(t *testing.T) {

--- a/tests/soundex_test.go
+++ b/tests/soundex_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/neuneck/smetrics"
 )
 
 func TestSoundex(t *testing.T) {

--- a/tests/ukkonen_test.go
+++ b/tests/ukkonen_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/neuneck/smetrics"
 )
 
 func TestUkkonen(t *testing.T) {

--- a/tests/wagner-fischer_test.go
+++ b/tests/wagner-fischer_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/xrash/smetrics"
 	"testing"
+
+	"github.com/neuneck/smetrics"
 )
 
 func TestWagnerFischer(t *testing.T) {

--- a/wagner-fischer.go
+++ b/wagner-fischer.go
@@ -1,5 +1,7 @@
 package smetrics
 
+const maxStackStringLength = 256
+
 // BytePair structs hold a pair of bytes
 type BytePair struct {
 	firstByte  byte
@@ -71,10 +73,20 @@ func WagnerFischer(aStr, bStr string, icost, dcost, scost int) int {
 	a := []rune(aStr)
 	b := []rune(bStr)
 
-	// Allocate both rows.
-	row1 := make([]int, len(b)+1)
-	row2 := make([]int, len(b)+1)
-	var tmp []int
+	// Allocate memory stores on the stack if possible, otherwise use heap memory
+	var row1, row2, tmp []int
+	if len(a)+1 < maxStackStringLength && len(b)+1 < maxStackStringLength {
+		var (
+			store1 [maxStackStringLength]int
+			store2 [maxStackStringLength]int
+		)
+
+		row1 = store1[:len(b)+1]
+		row2 = store2[:len(b)+1]
+	} else {
+		row1 = make([]int, len(b)+1)
+		row2 = make([]int, len(b)+1)
+	}
 
 	// Initialize the first row.
 	for i := 1; i <= len(b); i++ {
@@ -116,10 +128,21 @@ func WagnerFischer(aStr, bStr string, icost, dcost, scost int) int {
 
 // WagnerFischerWithWeightedSubs computes the Levenshtein Distance with substitution weights given as a map of bytes to maps of bytes to int
 func WagnerFischerWithWeightedSubs(a, b string, icost, dcost, scost int, substitutionWeights map[BytePair]int) int {
-	// Allocate both rows.
-	row1 := make([]int, len(b)+1)
-	row2 := make([]int, len(b)+1)
-	var tmp []int
+
+	// Allocate memory stores on the stack if possible, otherwise use heap memory
+	var row1, row2, tmp []int
+	if len(a)+1 < maxStackStringLength && len(b)+1 < maxStackStringLength {
+		var (
+			store1 [maxStackStringLength]int
+			store2 [maxStackStringLength]int
+		)
+
+		row1 = store1[:len(b)+1]
+		row2 = store2[:len(b)+1]
+	} else {
+		row1 = make([]int, len(b)+1)
+		row2 = make([]int, len(b)+1)
+	}
 
 	// Initialize the first row.
 	for i := 1; i <= len(b); i++ {


### PR DESCRIPTION
Implement adaptive use of stack allocations in favor of heap allocations for short (in practice most) strings to minimize memory churn.

The idea is that the temporary int slices representing the rows currently are allocated on heap, which causes significant memory churn when comparing large numbers of candidates. This PR instead uses array stores allocated on the stack for all strings <256 characters (for practical scenarios probably >99% of all cases this package is used for), making processing close to zero-allocative.

In addition, internal test dependencies were corrected to actually use this package instead of the upstream repo ;-)